### PR TITLE
Fix warning about egrep being obsolete

### DIFF
--- a/lib/json.bash
+++ b/lib/json.bash
@@ -26,13 +26,13 @@ json_tokenize() {
   local ESCAPE
   local CHAR
 
-  if echo "test string" | egrep -ao --color=never "test" >/dev/null 2>&1; then
-    GREP='egrep -ao --color=never'
+  if echo "test string" | grep -Eao --color=never "test" >/dev/null 2>&1; then
+    GREP='grep -Eao --color=never'
   else
-    GREP='egrep -ao'
+    GREP='grep -Eao'
   fi
 
-  if echo "test string" | egrep -o "test" >/dev/null 2>&1; then
+  if echo "test string" | grep -Eo "test" >/dev/null 2>&1; then
     ESCAPE='(\\[^u[:cntrl:]]|\\u[0-9a-fA-F]{4})'
     CHAR='[^[:cntrl:]"\\]'
   else
@@ -49,7 +49,7 @@ json_tokenize() {
   # Force zsh to expand $A into multiple words
   local is_wordsplit_disabled=$(unsetopt 2>/dev/null | grep -c '^shwordsplit$')
   if [ $is_wordsplit_disabled != 0 ]; then setopt shwordsplit; fi
-  $GREP "$STRING|$NUMBER|$KEYWORD|$SPACE|." | egrep -v "^$SPACE$"
+  $GREP "$STRING|$NUMBER|$KEYWORD|$SPACE|." | grep -Ev "^$SPACE$"
   if [ $is_wordsplit_disabled != 0 ]; then unsetopt shwordsplit; fi
 }
 


### PR DESCRIPTION
I replaced all occurrences of `egrep` with `grep -E` because I found the warnings annoying and ugly.

The warning:
> egrep: warning: egrep is obsolescent; using grep -E